### PR TITLE
Fixed orderBy not added to generated SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ process.env.ROBOT_SHEET_NAME = 'Passed'
 process.env.ROBOT_IMPORT_POLICE_API_URL = 'http://localhost/force'
 ```
 
-## Licence
+## Licence 
 
 THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 

--- a/app/repos/cdo.js
+++ b/app/repos/cdo.js
@@ -29,8 +29,10 @@ const createCdo = async (data, transaction) => {
 }
 
 const getCdo = async (indexNumber) => {
-  const cdo = await sequelize.models.dog.findOne({
+  const cdo = await sequelize.models.dog.findAll({
     where: { index_number: indexNumber },
+    order: [[sequelize.col('registered_person.person.addresses.address.id'), 'DESC'],
+      [sequelize.col('dog_microchips.microchip.id'), 'ASC']],
     include: [{
       model: sequelize.models.registered_person,
       as: 'registered_person',
@@ -104,9 +106,6 @@ const getCdo = async (indexNumber) => {
     {
       model: sequelize.models.dog_microchip,
       as: 'dog_microchips',
-      order: [
-        ['id', 'ASC']
-      ],
       include: [{
         model: sequelize.models.microchip,
         as: 'microchip'
@@ -114,12 +113,13 @@ const getCdo = async (indexNumber) => {
     }]
   })
 
-  return cdo
+  return cdo?.length > 0 ? cdo[0] : null
 }
 
 const getAllCdos = async () => {
   const cdos = await sequelize.models.dog.findAll({
-    order: [['id']],
+    order: [[sequelize.col('registered_person.person.addresses.address.id'), 'DESC'],
+      [sequelize.col('dog_microchips.microchip.id'), 'ASC']],
     include: [{
       model: sequelize.models.registered_person,
       as: 'registered_person',
@@ -189,9 +189,6 @@ const getAllCdos = async () => {
     {
       model: sequelize.models.dog_microchip,
       as: 'dog_microchips',
-      order: [
-        ['id', 'ASC']
-      ],
       include: [{
         model: sequelize.models.microchip,
         as: 'microchip'

--- a/app/repos/microchip.js
+++ b/app/repos/microchip.js
@@ -19,9 +19,7 @@ const updateMicrochip = async (dogFromDb, newMicrochipNumber, position, transact
 
 const getMicrochipDetails = async (dogId, position, transaction) => {
   const microchips = await sequelize.models.microchip.findAll({
-    order: [
-      ['id', 'ASC']
-    ],
+    order: [[sequelize.col('dog_microchips.id'), 'ASC']],
     include: [{
       model: sequelize.models.dog_microchip,
       as: 'dog_microchips',

--- a/app/repos/search.js
+++ b/app/repos/search.js
@@ -8,6 +8,7 @@ const addToSearchIndex = async (person, dogId, transaction) => {
   }
 
   const dog = await dbFindByPk(sequelize.models.dog, dogId, {
+    order: [[sequelize.col('dog_microchips.id'), 'ASC']],
     include: [{
       model: sequelize.models.status,
       as: 'status'
@@ -15,7 +16,6 @@ const addToSearchIndex = async (person, dogId, transaction) => {
     {
       model: sequelize.models.dog_microchip,
       as: 'dog_microchips',
-      order: [['id', 'ASC']],
       include: [{
         model: sequelize.models.microchip,
         as: 'microchip'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aphw-ddi-api",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "API to manage CRUD / query functions for dangerous dogs register",
   "homepage": "https://github.com/DEFRA/aphw-ddi-api",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/cdo.test.js
+++ b/test/integration/narrow/routes/cdo.test.js
@@ -46,7 +46,6 @@ describe('CDO endpoint', () => {
     }
 
     const response = await server.inject(options)
-    console.log('response', response)
     expect(response.statusCode).toBe(200)
   })
 

--- a/test/integration/narrow/routes/cdo.test.js
+++ b/test/integration/narrow/routes/cdo.test.js
@@ -46,6 +46,7 @@ describe('CDO endpoint', () => {
     }
 
     const response = await server.inject(options)
+    console.log('response', response)
     expect(response.statusCode).toBe(200)
   })
 

--- a/test/mocks/cdo/create-enhanced.js
+++ b/test/mocks/cdo/create-enhanced.js
@@ -1,0 +1,36 @@
+const payload = {
+  owner: {
+    firstName: 'Joe',
+    lastName: 'Bloggs',
+    dateOfBirth: '1998-05-10',
+    address: {
+      addressLine1: '14 Fake Street',
+      town: 'Fake Town',
+      postcode: 'FA1 2KE'
+    },
+    email: 'me@here.com',
+    primaryTelephone: '01911234567',
+    secondaryTelephone: '01911234555'
+  },
+  enforcementDetails: {
+    policeForce: '1',
+    court: '1',
+    legislationOfficer: 'John Smith'
+  },
+  dogs: [
+    {
+      breed: 'Pit Bull Terrier',
+      name: 'Buster',
+      cdoIssued: '2023-10-10',
+      cdoExpiry: '2023-12-10'
+    },
+    {
+      breed: 'XL Bully',
+      name: 'Alice',
+      cdoIssued: '2023-10-10',
+      cdoExpiry: '2023-12-10'
+    }
+  ]
+}
+
+module.exports = payload

--- a/test/unit/app/export/csv.test.js
+++ b/test/unit/app/export/csv.test.js
@@ -31,7 +31,6 @@ describe('CSV test', () => {
     const csvData = csv.substring(csv.indexOf('\n') + 1)
     expect(csvHeader).toBe(validHeader)
     const csvDataArray = csvData.split(',')
-    console.log('csvData', csvData)
     expect(csvDataArray[0]).toBe('"P-123-456"')
     expect(csvDataArray[1]).toBe('"John"')
     expect(csvDataArray[2]).toBe('"Smith"')

--- a/test/unit/app/repos/cdo.test.js
+++ b/test/unit/app/repos/cdo.test.js
@@ -3,6 +3,7 @@ const mockCdoPayload = require('../../../mocks/cdo/create')
 describe('CDO repo', () => {
   jest.mock('../../../../app/config/db', () => ({
     transaction: jest.fn(),
+    col: jest.fn(),
     models: {
       dog: {
         findOne: jest.fn(),
@@ -70,10 +71,10 @@ describe('CDO repo', () => {
   })
 
   test('getCdo should return CDO', async () => {
-    sequelize.models.dog.findOne.mockResolvedValue({ id: 123, breed: 'breed', name: 'Bruno' })
+    sequelize.models.dog.findAll.mockResolvedValue([{ id: 123, breed: 'breed', name: 'Bruno' }])
 
     const res = await getCdo('ED123')
-    expect(sequelize.models.dog.findOne).toHaveBeenCalledTimes(1)
+    expect(sequelize.models.dog.findAll).toHaveBeenCalledTimes(1)
     expect(res).not.toBe(null)
     expect(res.id).toBe(123)
   })

--- a/test/unit/app/repos/dogs.test.js
+++ b/test/unit/app/repos/dogs.test.js
@@ -32,6 +32,7 @@ describe('Dog repo', () => {
         create: jest.fn()
       }
     },
+    col: jest.fn(),
     transaction: jest.fn()
   }))
 

--- a/test/unit/app/repos/people.test.js
+++ b/test/unit/app/repos/people.test.js
@@ -29,6 +29,7 @@ describe('People repo', () => {
         create: jest.fn()
       }
     },
+    col: jest.fn(),
     transaction: jest.fn()
   }))
 
@@ -138,7 +139,7 @@ describe('People repo', () => {
   })
 
   test('getPersonByReference should return person', async () => {
-    sequelize.models.person.findOne.mockResolvedValue({
+    sequelize.models.registered_person.findAll.mockResolvedValue([{
       dataValues: {
         id: 1,
         first_name: 'First',
@@ -154,9 +155,11 @@ describe('People repo', () => {
           }
         ]
       }
-    })
+    }])
 
     const person = await getPersonByReference('1234')
+
+    console.log('person', JSON.parse(JSON.stringify(person)))
 
     expect(person).toEqual({
       dataValues: {
@@ -178,13 +181,13 @@ describe('People repo', () => {
   })
 
   test('getPersonByReference should throw if error', async () => {
-    sequelize.models.person.findOne.mockRejectedValue(new Error('Test error'))
+    sequelize.models.registered_person.findAll.mockRejectedValue(new Error('Test error'))
 
     await expect(getPersonByReference('1234')).rejects.toThrow('Test error')
   })
 
   test('getPersonAndDogsByReference should return person and dogs', async () => {
-    sequelize.models.registered_person.findAll.mockResolvedValue({
+    sequelize.models.registered_person.findAll.mockResolvedValue([{
       dataValues: {
         person: [
           {
@@ -208,7 +211,7 @@ describe('People repo', () => {
           }
         ]
       }
-    })
+    }])
 
     const personAndDogs = await getPersonAndDogsByReference('P-1234')
 
@@ -285,7 +288,7 @@ describe('People repo', () => {
       }
     }
 
-    sequelize.models.person.findOne.mockResolvedValue({
+    sequelize.models.registered_person.findAll.mockResolvedValue([{
       id: 1,
       first_name: 'First',
       last_name: 'Last',
@@ -303,7 +306,7 @@ describe('People repo', () => {
         }
       ],
       person_contacts: []
-    })
+    }])
 
     await updatePerson(person, {})
 
@@ -327,7 +330,7 @@ describe('People repo', () => {
       }
     }
 
-    sequelize.models.person.findOne.mockResolvedValue({
+    sequelize.models.registered_person.findAll.mockResolvedValue([{
       id: 1,
       first_name: 'First',
       last_name: 'Last',
@@ -345,7 +348,7 @@ describe('People repo', () => {
         }
       ],
       person_contacts: []
-    })
+    }])
 
     sequelize.models.address.findByPk.mockResolvedValue({
       id: 1,
@@ -387,7 +390,7 @@ describe('People repo', () => {
       }
     }
 
-    sequelize.models.person.findOne.mockResolvedValue({
+    sequelize.models.registered_person.findAll.mockResolvedValue([{
       id: 1,
       first_name: 'First',
       last_name: 'Last',
@@ -405,7 +408,7 @@ describe('People repo', () => {
         }
       ],
       person_contacts: []
-    })
+    }])
 
     sequelize.models.address.findByPk.mockResolvedValue({
       id: 1,
@@ -439,7 +442,7 @@ describe('People repo', () => {
       email: 'test_3@example.com'
     }
 
-    sequelize.models.person.findOne.mockResolvedValue({
+    sequelize.models.registered_person.findAll.mockResolvedValue([{
       id: 1,
       first_name: 'First',
       last_name: 'Last',
@@ -465,7 +468,7 @@ describe('People repo', () => {
           }
         }
       ]
-    })
+    }])
 
     sequelize.models.contact.create.mockResolvedValue({
       id: 2,

--- a/test/unit/app/repos/search.test.js
+++ b/test/unit/app/repos/search.test.js
@@ -10,6 +10,7 @@ describe('Search repo', () => {
         findAll: jest.fn()
       }
     },
+    col: jest.fn(),
     transaction: jest.fn(),
     fn: jest.fn()
   }))


### PR DESCRIPTION
Fixed order by problems where 'order by' not being added to SQL and therefore no ordering being performed
findOne does not seem to support orderBy of a sub-clause columns, so findOne queries have been changed to findAll