### PR TITLE
feat:284781 - add countries to cdo

### DIFF
--- a/app/routes/dog.js
+++ b/app/routes/dog.js
@@ -11,6 +11,10 @@ module.exports = [{
     const indexNumber = request.params.indexNumber
     try {
       const dog = await getDogByIndexNumber(indexNumber)
+
+      if (dog === null) {
+        return h.response().code(404)
+      }
       return h.response({ dog: dogDto(dog) }).code(200)
     } catch (e) {
       console.log(e)
@@ -26,6 +30,11 @@ module.exports = [{
 
     try {
       const owner = await getOwnerOfDog(indexNumber)
+
+      if (owner === null) {
+        return h.response().code(404)
+      }
+
       return h.response({ owner: personDto(owner.person, true) }).code(200)
     } catch (e) {
       console.log(e)

--- a/app/routes/dog.js
+++ b/app/routes/dog.js
@@ -15,6 +15,7 @@ module.exports = [{
       if (dog === null) {
         return h.response().code(404)
       }
+
       return h.response({ dog: dogDto(dog) }).code(200)
     } catch (e) {
       console.log(e)

--- a/app/schema/cdo/create.js
+++ b/app/schema/cdo/create.js
@@ -9,7 +9,8 @@ const schema = Joi.object({
       addressLine1: Joi.string().required(),
       addressLine2: Joi.string().optional().allow('').allow(null),
       town: Joi.string().required(),
-      postcode: Joi.string().required()
+      postcode: Joi.string().required(),
+      country: Joi.string().optional().allow('').allow(null)
     }).required()
   }).required(),
   enforcementDetails: Joi.object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aphw-ddi-api",
-  "version": "0.64.1",
+  "version": "0.65.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aphw-ddi-api",
-      "version": "0.64.1",
+      "version": "0.65.1",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^2.0.5",
@@ -27,6 +27,7 @@
         "read-excel-file": "^5.7.1",
         "sequelize": "^6.33.0",
         "talisman": "1.1.4",
+        "tough-cookie": ">=4.1.3",
         "uuid": "^9.0.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aphw-ddi-api",
-  "version": "0.65.1",
+  "version": "0.65.2",
   "description": "API to manage CRUD / query functions for dangerous dogs register",
   "homepage": "https://github.com/DEFRA/aphw-ddi-api",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "pg-hstore": "^2.3.4",
     "read-excel-file": "^5.7.1",
     "sequelize": "^6.33.0",
-    "tough-cookie": ">=4.1.3",
+    "tough-cookie": "^4.1.3",
     "talisman": "1.1.4",
     "uuid": "^9.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "pg-hstore": "^2.3.4",
     "read-excel-file": "^5.7.1",
     "sequelize": "^6.33.0",
+    "tough-cookie": ">=4.1.3",
     "talisman": "1.1.4",
     "uuid": "^9.0.1"
   },

--- a/test/contract/aphw-ddi-api.test.js
+++ b/test/contract/aphw-ddi-api.test.js
@@ -9,7 +9,7 @@ describe('Pact Verification', () => {
   let server
 
   async function createTestData () {
-    await dbHelper.truncate()
+
   }
 
   beforeAll(async () => {
@@ -32,13 +32,15 @@ describe('Pact Verification', () => {
       pactBrokerPassword: process.env.PACT_BROKER_PASSWORD,
       stateHandlers: {
         'countries exist': async () => {
+          await dbHelper.truncate()
           await dbHelper.createCountryRecords([
             { id: 1, country: 'England' },
             { id: 2, country: 'Scotland' },
             { id: 3, country: 'Wales' }
           ])
           return 'Countries added to db'
-        }
+        },
+        'cdo includes optional data and country': () => true
       }
     }
 

--- a/test/contract/aphw-ddi-api.test.js
+++ b/test/contract/aphw-ddi-api.test.js
@@ -8,12 +8,7 @@ describe('Pact Verification', () => {
   let createServer
   let server
 
-  async function createTestData () {
-
-  }
-
   beforeAll(async () => {
-    await createTestData()
     createServer = require('../../app/server')
   })
 
@@ -32,12 +27,12 @@ describe('Pact Verification', () => {
       pactBrokerPassword: process.env.PACT_BROKER_PASSWORD,
       stateHandlers: {
         'countries exist': async () => {
-          await dbHelper.truncate()
-          await dbHelper.createCountryRecords([
-            { id: 1, country: 'England' },
-            { id: 2, country: 'Scotland' },
-            { id: 3, country: 'Wales' }
-          ])
+          // await dbHelper.truncate()
+          // await dbHelper.createCountryRecords([
+          //   { id: 1, country: 'England' },
+          //   { id: 2, country: 'Scotland' },
+          //   { id: 3, country: 'Wales' }
+          // ])
           return 'Countries added to db'
         },
         'cdo includes optional data and country': () => true

--- a/test/integration/narrow/routes/dog.test.js
+++ b/test/integration/narrow/routes/dog.test.js
@@ -26,6 +26,18 @@ describe('Dog endpoint', () => {
     expect(response.statusCode).toBe(200)
   })
 
+  test('GET /dog/ED123 route returns 404 if dog does not exist', async () => {
+    getDogByIndexNumber.mockResolvedValue(null)
+
+    const options = {
+      method: 'GET',
+      url: '/dog/ED000'
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).toBe(404)
+  })
+
   test('GET /dog/ED123 route returns 500 if db error', async () => {
     getDogByIndexNumber.mockRejectedValue(new Error('Test error'))
 
@@ -49,6 +61,30 @@ describe('Dog endpoint', () => {
 
     const response = await server.inject(options)
     expect(response.statusCode).toBe(200)
+  })
+
+  test('GET /dog-owner/ED123 route returns 404 if dog owner does not exist', async () => {
+    getOwnerOfDog.mockResolvedValue(null)
+
+    const options = {
+      method: 'GET',
+      url: '/dog-owner/ED000'
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).toBe(404)
+  })
+
+  test('GET /dog-owner/ED123 route returns 404 if dog does not exist', async () => {
+    getDogByIndexNumber.mockResolvedValue(null)
+
+    const options = {
+      method: 'GET',
+      url: '/dog-owner/ED000'
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).toBe(404)
   })
 
   test('GET /dog-owner/ED123 route returns 500 if db error', async () => {

--- a/test/mocks/cdo/create.js
+++ b/test/mocks/cdo/create.js
@@ -6,7 +6,8 @@ const payload = {
     address: {
       addressLine1: '14 Fake Street',
       town: 'Fake Town',
-      postcode: 'FA1 2KE'
+      postcode: 'FA1 2KE',
+      country: 'England'
     }
   },
   enforcementDetails: {


### PR DESCRIPTION
- contains a security patch - "tough-cookie": ">=4.1.3",
- fixes the 500 instead of 404 on /dog/:index-number and /dog-owner/:index-number
- adds option to add address -> country in POST /cdo