### PR TITLE
feat: 279887 - Manage Cdo skeleton endpoint with fixed return

### DIFF
--- a/app/routes/cdo.js
+++ b/app/routes/cdo.js
@@ -4,48 +4,121 @@ const { getCallingUser } = require('../auth/get-user')
 const cdoCreateSchema = require('../schema/cdo/create')
 const { NotFoundError } = require('../errors/not-found')
 
-module.exports = [{
-  method: 'GET',
-  path: '/cdo/{indexNumber}',
-  handler: async (request, h) => {
-    const indexNumber = request.params.indexNumber
-    try {
-      const cdo = await getCdo(indexNumber)
-
-      if (!cdo) {
-        return h.response().code(404)
-      }
-
-      return h.response({ cdo: cdoViewDto(cdo) }).code(200)
-    } catch (e) {
-      console.log('Error retrieving cdo record:', e)
-      throw e
-    }
-  }
-},
-{
-  method: 'POST',
-  path: '/cdo',
-  options: {
-    validate: {
-      payload: cdoCreateSchema,
-      failAction: (request, h, err) => {
-        console.error(err)
-
-        return h.response({ errors: err.details.map(e => e.message) }).code(400).takeover()
-      }
-    },
+module.exports = [
+  {
+    method: 'GET',
+    path: '/cdo/{indexNumber}',
     handler: async (request, h) => {
+      const indexNumber = request.params.indexNumber
       try {
-        const created = await createCdo(request.payload, getCallingUser(request))
-        const res = cdoCreateDto(created)
-        return h.response(res).code(200)
-      } catch (e) {
-        if (e instanceof NotFoundError) {
-          return h.response().code(422).takeover()
+        const cdo = await getCdo(indexNumber)
+
+        if (!cdo) {
+          return h.response().code(404)
         }
+
+        return h.response({ cdo: cdoViewDto(cdo) }).code(200)
+      } catch (e) {
+        console.log('Error retrieving cdo record:', e)
+        throw e
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: '/cdo',
+    options: {
+      validate: {
+        payload: cdoCreateSchema,
+        failAction: (request, h, err) => {
+          console.error(err)
+
+          return h.response({ errors: err.details.map(e => e.message) }).code(400).takeover()
+        }
+      },
+      handler: async (request, h) => {
+        try {
+          const created = await createCdo(request.payload, getCallingUser(request))
+          const res = cdoCreateDto(created)
+          return h.response(res).code(200)
+        } catch (e) {
+          if (e instanceof NotFoundError) {
+            return h.response().code(422).takeover()
+          }
+          throw e
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/cdo/{indexNumber}/manage',
+    handler: async (request, h) => {
+      const indexNumber = request.params.indexNumber
+      try {
+        const cdo = await getCdo(indexNumber)
+
+        if (!cdo) {
+          return h.response().code(404)
+        }
+
+        const tasks = {
+          applicationPackSent: {
+            key: 'applicationPackSent',
+            available: true,
+            completed: false,
+            editable: true,
+            timestamp: undefined
+          },
+          insuranceDetailsRecorded: {
+            key: 'insuranceDetailsRecorded',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          microchipNumberRecorded: {
+            key: 'microchipNumberRecorded',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          applicationFeePaid: {
+            key: 'applicationFeePaid',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          form2Sent: {
+            key: 'form2Sent',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          verificationDateRecorded: {
+            key: 'verificationDateRecorded',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          certificateIssued: {
+            key: 'certificateIssued',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          }
+        }
+
+        return h.response({ tasks }).code(200)
+      } catch (e) {
+        console.log('Error retrieving cdo record:', e)
         throw e
       }
     }
   }
-}]
+]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aphw-ddi-api",
-  "version": "0.71.20",
+  "version": "0.71.21",
   "description": "API to manage CRUD / query functions for dangerous dogs register",
   "homepage": "https://github.com/DEFRA/aphw-ddi-api",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/cdo.test.js
+++ b/test/integration/narrow/routes/cdo.test.js
@@ -51,6 +51,18 @@ describe('CDO endpoint', () => {
       expect(response.statusCode).toBe(200)
     })
 
+    test('GET /cdo/ED123 route returns 404 when not found', async () => {
+      getCdo.mockResolvedValue(null)
+
+      const options = {
+        method: 'GET',
+        url: '/cdo/ED123'
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(404)
+    })
+
     test('GET /cdo/ED123 route returns 500 when error', async () => {
       getCdo.mockImplementation(() => { throw new Error('cdo error') })
 
@@ -360,6 +372,18 @@ describe('CDO endpoint', () => {
 
       const response = await server.inject(options)
       expect(response.statusCode).toBe(404)
+    })
+
+    test('should returns 500 given server error thrown', async () => {
+      getCdo.mockImplementation(() => { throw new Error('cdo error') })
+
+      const options = {
+        method: 'GET',
+        url: '/cdo/ED123/manage'
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(500)
     })
   })
 })

--- a/test/integration/narrow/routes/cdo.test.js
+++ b/test/integration/narrow/routes/cdo.test.js
@@ -14,246 +14,352 @@ describe('CDO endpoint', () => {
     await server.initialize()
   })
 
-  test('GET /cdo/ED123 route returns 200', async () => {
-    getCdo.mockResolvedValue({
-      id: 123,
-      indexNumber: 'ED123',
-      dog_breed: {
-        breed: 'breed1'
-      },
-      status: {
-        status: 'NEW'
-      },
-      registration: {
-        court: {
-          name: 'court1'
+  describe('GET /cdo/ED123', () => {
+    test('GET /cdo/ED123 route returns 200', async () => {
+      getCdo.mockResolvedValue({
+        id: 123,
+        indexNumber: 'ED123',
+        dog_breed: {
+          breed: 'breed1'
         },
-        police_force: {
-          name: 'force1'
+        status: {
+          status: 'NEW'
         },
-        exemption_order: {
-          exemption_order: 2015
-        }
-      },
-      registered_person: [{
-        person: {
-        }
-      }]
-    })
-
-    const options = {
-      method: 'GET',
-      url: '/cdo/ED123'
-    }
-
-    const response = await server.inject(options)
-    expect(response.statusCode).toBe(200)
-  })
-
-  test('GET /cdo/ED123 route returns 500 when error', async () => {
-    getCdo.mockImplementation(() => { throw new Error('cdo error') })
-
-    const options = {
-      method: 'GET',
-      url: '/cdo/ED123'
-    }
-
-    const response = await server.inject(options)
-    expect(response.statusCode).toBe(500)
-  })
-
-  test('POST /cdo route returns 200 with valid payload', async () => {
-    const options = {
-      method: 'POST',
-      url: '/cdo',
-      payload: mockCreatePayload
-    }
-
-    createCdo.mockResolvedValue({
-      owner: {
-        first_name: 'John',
-        last_name: 'Doe',
-        birth_date: '1990-01-01',
-        address: {
-          address_line_1: '1 Test Street',
-          address_line_2: 'Test',
-          town: 'Test',
-          postcode: 'TE1 1ST',
-          country: {
-            country: 'England'
-          }
-        },
-        person_reference: '1234'
-      },
-      dogs: [
-        {
-          index_number: 'ED10000',
-          name: 'Test Dog',
-          dog_breed: {
-            breed: 'Test Breed'
+        registration: {
+          court: {
+            name: 'court1'
           },
-          registration: {
-            police_force: {
-              name: 'Test Police Force'
-            },
-            court: {
-              name: 'Test Court'
-            },
-            cdo_issued: '2020-01-01',
-            cdo_expiry: '2020-02-01',
-            legislation_officer: 'Test Officer'
-          }
-        }
-      ]
-    })
-
-    const response = await server.inject(options)
-    expect(response.statusCode).toBe(200)
-    expect(response.result).toEqual({
-      owner: {
-        firstName: 'John',
-        lastName: 'Doe',
-        birthDate: '1990-01-01',
-        address: {
-          addressLine1: '1 Test Street',
-          addressLine2: 'Test',
-          town: 'Test',
-          postcode: 'TE1 1ST',
-          country: 'England'
-        },
-        personReference: '1234'
-      },
-      enforcementDetails: {
-        policeForce: 'Test Police Force',
-        court: 'Test Court',
-        legislationOfficer: 'Test Officer'
-      },
-      dogs: [
-        {
-          indexNumber: 'ED10000',
-          name: 'Test Dog',
-          breed: 'Test Breed',
-          cdoIssued: '2020-01-01',
-          cdoExpiry: '2020-02-01'
-        }
-      ]
-    })
-  })
-
-  test('POST /cdo route returns 200 with valid payload and personReference', async () => {
-    const options = {
-      method: 'POST',
-      url: '/cdo',
-      payload: mockCreateWithRefPayload
-    }
-
-    createCdo.mockResolvedValue({
-      owner: {
-        first_name: 'John',
-        last_name: 'Doe',
-        birth_date: '1990-01-01',
-        address: {
-          address_line_1: '1 Test Street',
-          address_line_2: 'Test',
-          town: 'Test',
-          postcode: 'TE1 1ST',
-          country: {
-            country: 'England'
-          }
-        },
-        person_reference: 'P-6076-A37C'
-      },
-      dogs: [
-        {
-          index_number: 'ED10000',
-          name: 'Test Dog',
-          dog_breed: {
-            breed: 'Test Breed'
+          police_force: {
+            name: 'force1'
           },
-          registration: {
-            police_force: {
-              name: 'Test Police Force'
+          exemption_order: {
+            exemption_order: 2015
+          }
+        },
+        registered_person: [{
+          person: {
+          }
+        }]
+      })
+
+      const options = {
+        method: 'GET',
+        url: '/cdo/ED123'
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(200)
+    })
+
+    test('GET /cdo/ED123 route returns 500 when error', async () => {
+      getCdo.mockImplementation(() => { throw new Error('cdo error') })
+
+      const options = {
+        method: 'GET',
+        url: '/cdo/ED123'
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(500)
+    })
+  })
+
+  describe('POST /cdo', () => {
+    test('POST /cdo route returns 200 with valid payload', async () => {
+      const options = {
+        method: 'POST',
+        url: '/cdo',
+        payload: mockCreatePayload
+      }
+
+      createCdo.mockResolvedValue({
+        owner: {
+          first_name: 'John',
+          last_name: 'Doe',
+          birth_date: '1990-01-01',
+          address: {
+            address_line_1: '1 Test Street',
+            address_line_2: 'Test',
+            town: 'Test',
+            postcode: 'TE1 1ST',
+            country: {
+              country: 'England'
+            }
+          },
+          person_reference: '1234'
+        },
+        dogs: [
+          {
+            index_number: 'ED10000',
+            name: 'Test Dog',
+            dog_breed: {
+              breed: 'Test Breed'
             },
-            court: {
-              name: 'Test Court'
+            registration: {
+              police_force: {
+                name: 'Test Police Force'
+              },
+              court: {
+                name: 'Test Court'
+              },
+              cdo_issued: '2020-01-01',
+              cdo_expiry: '2020-02-01',
+              legislation_officer: 'Test Officer'
+            }
+          }
+        ]
+      })
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(200)
+      expect(response.result).toEqual({
+        owner: {
+          firstName: 'John',
+          lastName: 'Doe',
+          birthDate: '1990-01-01',
+          address: {
+            addressLine1: '1 Test Street',
+            addressLine2: 'Test',
+            town: 'Test',
+            postcode: 'TE1 1ST',
+            country: 'England'
+          },
+          personReference: '1234'
+        },
+        enforcementDetails: {
+          policeForce: 'Test Police Force',
+          court: 'Test Court',
+          legislationOfficer: 'Test Officer'
+        },
+        dogs: [
+          {
+            indexNumber: 'ED10000',
+            name: 'Test Dog',
+            breed: 'Test Breed',
+            cdoIssued: '2020-01-01',
+            cdoExpiry: '2020-02-01'
+          }
+        ]
+      })
+    })
+
+    test('POST /cdo route returns 200 with valid payload and personReference', async () => {
+      const options = {
+        method: 'POST',
+        url: '/cdo',
+        payload: mockCreateWithRefPayload
+      }
+
+      createCdo.mockResolvedValue({
+        owner: {
+          first_name: 'John',
+          last_name: 'Doe',
+          birth_date: '1990-01-01',
+          address: {
+            address_line_1: '1 Test Street',
+            address_line_2: 'Test',
+            town: 'Test',
+            postcode: 'TE1 1ST',
+            country: {
+              country: 'England'
+            }
+          },
+          person_reference: 'P-6076-A37C'
+        },
+        dogs: [
+          {
+            index_number: 'ED10000',
+            name: 'Test Dog',
+            dog_breed: {
+              breed: 'Test Breed'
             },
-            cdo_issued: '2020-01-01',
-            cdo_expiry: '2020-02-01',
-            legislation_officer: 'Test Officer'
+            registration: {
+              police_force: {
+                name: 'Test Police Force'
+              },
+              court: {
+                name: 'Test Court'
+              },
+              cdo_issued: '2020-01-01',
+              cdo_expiry: '2020-02-01',
+              legislation_officer: 'Test Officer'
+            }
+          }
+        ]
+      })
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(200)
+      expect(response.result).toEqual({
+        owner: {
+          firstName: 'John',
+          lastName: 'Doe',
+          birthDate: '1990-01-01',
+          address: {
+            addressLine1: '1 Test Street',
+            addressLine2: 'Test',
+            town: 'Test',
+            postcode: 'TE1 1ST',
+            country: 'England'
+          },
+          personReference: 'P-6076-A37C'
+        },
+        enforcementDetails: {
+          policeForce: 'Test Police Force',
+          court: 'Test Court',
+          legislationOfficer: 'Test Officer'
+        },
+        dogs: [
+          {
+            indexNumber: 'ED10000',
+            name: 'Test Dog',
+            breed: 'Test Breed',
+            cdoIssued: '2020-01-01',
+            cdoExpiry: '2020-02-01'
+          }
+        ]
+      })
+    })
+
+    test('POST /cdo route returns 422 with invalid personReference', async () => {
+      const options = {
+        method: 'POST',
+        url: '/cdo',
+        payload: mockCreateWithRefPayload
+      }
+
+      createCdo.mockRejectedValue(new NotFoundError('Owner not found'))
+
+      const response = await server.inject(options)
+
+      expect(response.statusCode).toBe(422)
+    })
+
+    test('POST /cdo route returns 400 with invalid payload', async () => {
+      const options = {
+        method: 'POST',
+        url: '/cdo',
+        payload: {}
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(400)
+    })
+
+    test('POST /cdo route returns 500 if db error', async () => {
+      createCdo.mockRejectedValue(new Error('Test error'))
+
+      const options = {
+        method: 'POST',
+        url: '/cdo',
+        payload: mockCreatePayload
+      }
+
+      const response = await server.inject(options)
+
+      expect(response.statusCode).toBe(500)
+    })
+  })
+
+  describe('GET /cdo/ED123/manage', () => {
+    test('should return an initialised manage cdo task list', async () => {
+      getCdo.mockResolvedValue({
+        id: 123,
+        indexNumber: 'ED123',
+        dog_breed: {
+          breed: 'breed1'
+        },
+        status: {
+          status: 'NEW'
+        },
+        registration: {
+          court: {
+            name: 'court1'
+          },
+          police_force: {
+            name: 'force1'
+          },
+          exemption_order: {
+            exemption_order: 2015
+          }
+        },
+        registered_person: [{
+          person: {
+          }
+        }]
+      })
+      const options = {
+        method: 'GET',
+        url: '/cdo/ED123/manage'
+      }
+
+      const response = await server.inject(options)
+      const payload = JSON.parse(response.payload)
+      expect(response.statusCode).toBe(200)
+      expect(payload).toEqual({
+        tasks: {
+          applicationPackSent: {
+            key: 'applicationPackSent',
+            available: true,
+            completed: false,
+            editable: true,
+            timestamp: undefined
+          },
+          insuranceDetailsRecorded: {
+            key: 'insuranceDetailsRecorded',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          microchipNumberRecorded: {
+            key: 'microchipNumberRecorded',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          applicationFeePaid: {
+            key: 'applicationFeePaid',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          form2Sent: {
+            key: 'form2Sent',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          verificationDateRecorded: {
+            key: 'verificationDateRecorded',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
+          },
+          certificateIssued: {
+            key: 'certificateIssued',
+            available: false,
+            completed: false,
+            editable: false,
+            timestamp: undefined
           }
         }
-      ]
+      })
     })
 
-    const response = await server.inject(options)
-    expect(response.statusCode).toBe(200)
-    expect(response.result).toEqual({
-      owner: {
-        firstName: 'John',
-        lastName: 'Doe',
-        birthDate: '1990-01-01',
-        address: {
-          addressLine1: '1 Test Street',
-          addressLine2: 'Test',
-          town: 'Test',
-          postcode: 'TE1 1ST',
-          country: 'England'
-        },
-        personReference: 'P-6076-A37C'
-      },
-      enforcementDetails: {
-        policeForce: 'Test Police Force',
-        court: 'Test Court',
-        legislationOfficer: 'Test Officer'
-      },
-      dogs: [
-        {
-          indexNumber: 'ED10000',
-          name: 'Test Dog',
-          breed: 'Test Breed',
-          cdoIssued: '2020-01-01',
-          cdoExpiry: '2020-02-01'
-        }
-      ]
+    test('should throw a 404 given index does not exist', async () => {
+      getCdo.mockResolvedValue(null)
+      const options = {
+        method: 'GET',
+        url: '/cdo/ED123/manage'
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(404)
     })
-  })
-
-  test('POST /cdo route returns 422 with invalid personReference', async () => {
-    const options = {
-      method: 'POST',
-      url: '/cdo',
-      payload: mockCreateWithRefPayload
-    }
-
-    createCdo.mockRejectedValue(new NotFoundError('Owner not found'))
-
-    const response = await server.inject(options)
-
-    expect(response.statusCode).toBe(422)
-  })
-
-  test('POST /cdo route returns 400 with invalid payload', async () => {
-    const options = {
-      method: 'POST',
-      url: '/cdo',
-      payload: {}
-    }
-
-    const response = await server.inject(options)
-    expect(response.statusCode).toBe(400)
-  })
-
-  test('POST /cdo route returns 500 if db error', async () => {
-    createCdo.mockRejectedValue(new Error('Test error'))
-
-    const options = {
-      method: 'POST',
-      url: '/cdo',
-      payload: mockCreatePayload
-    }
-
-    const response = await server.inject(options)
-
-    expect(response.statusCode).toBe(500)
   })
 })


### PR DESCRIPTION
Includes a formatting change to the cdo routes and test file.  Addition of one new endpoint GET /cdo/:index/manage with static return.