### PR TITLE
Feat/479647  application pack processed

### DIFF
--- a/app/constants/domain.js
+++ b/app/constants/domain.js
@@ -1,6 +1,7 @@
 const domain = {
   updateKeys: {
     applicationPackSent: ['applicationPackSent'],
+    applicationPackProcessed: ['applicationPackProcessed'],
     applicationFeePaid: ['applicationFeePaid'],
     applicationFeePaymentRecorded: ['applicationFeePaymentRecorded'],
     form2Sent: ['form2Sent'],
@@ -22,6 +23,7 @@ const domain = {
   },
   updateMappings: {
     applicationPackSent: 'dog.registration.application_pack_sent',
+    applicationPackProcessed: 'dog.registration.application_pack_processed',
     applicationFeePaid: 'dog.registration.application_fee_paid',
     form2Sent: 'dog.registration.form_two_sent',
     insuranceDetailsRecorded: 'dog.registration.insurance_details_recorded',

--- a/app/constants/event/events.js
+++ b/app/constants/event/events.js
@@ -18,6 +18,7 @@ module.exports = {
   CERTIFICATE_REQUESTED: 'uk.gov.defra.aphw.ddi.certificate.requested',
   activities: {
     applicationPackSent: 'Application pack',
+    applicationPackProcessed: 'Application pack',
     form2Sent: 'Form 2'
   }
 }

--- a/app/data/domain/cdoTaskList.js
+++ b/app/data/domain/cdoTaskList.js
@@ -56,11 +56,12 @@ class CdoTaskList {
 
   get _preCertificateStepsComplete () {
     return this.applicationPackSent.completed &&
-    this.insuranceDetailsRecorded.completed &&
-    this._preCertificateMicrochipStageComplete &&
-    this.applicationFeePaid.completed &&
-    this.form2Sent.completed &&
-    this.verificationDateRecorded.completed
+      this.applicationPackProcessed.completed &&
+      this.insuranceDetailsRecorded.completed &&
+      this._preCertificateMicrochipStageComplete &&
+      this.applicationFeePaid.completed &&
+      this.form2Sent.completed &&
+      this.verificationDateRecorded.completed
   }
 
   get cdoSummary () {
@@ -79,6 +80,7 @@ class CdoTaskList {
       id: this._cdo.dog.id,
       indexNumber: this._cdo.dog.indexNumber,
       applicationPackSent: this._cdo.exemption.applicationPackSent ?? undefined,
+      applicationPackProcessed: this._cdo.exemption.applicationPackProcessed ?? undefined,
       insuranceCompany: this._cdo.exemption.insurance[0]?.company ?? undefined,
       insuranceRenewal: this._cdo.exemption.insurance[0]?.renewalDate ?? undefined,
       microchipNumber,
@@ -106,6 +108,21 @@ class CdoTaskList {
       'applicationPackSent',
       {
         available: true,
+        completed,
+        readonly: completed
+      },
+      timestamp
+    )
+  }
+
+  get applicationPackProcessed () {
+    const timestamp = this._cdo.exemption.applicationPackProcessed ?? undefined
+    const completed = timestamp !== undefined
+
+    return new CdoTask(
+      'applicationPackProcessed',
+      {
+        available: this._actionPackStageComplete,
         completed,
         readonly: completed
       },
@@ -318,6 +335,14 @@ class CdoTaskList {
       throw new ActionAlreadyPerformedError('Application pack can only be sent once')
     }
     this._cdo.exemption.sendApplicationPack(sentDate, callback)
+  }
+
+  processApplicationPack (sentDate, callback) {
+    this._actionPackCompleteGuard()
+    if (this.applicationPackProcessed.completed) {
+      throw new ActionAlreadyPerformedError('Application pack can only be processed once')
+    }
+    this._cdo.exemption.processApplicationPack(sentDate, callback)
   }
 
   recordInsuranceDetails (company, renewalDate, callback) {

--- a/app/data/domain/exemption.js
+++ b/app/data/domain/exemption.js
@@ -47,6 +47,7 @@ class Exemption extends Changeable {
     this.joinedExemptionScheme = exemptionProperties.joinedExemptionScheme
     this.nonComplianceLetterSent = exemptionProperties.nonComplianceLetterSent
     this.applicationPackSent = exemptionProperties.applicationPackSent
+    this.applicationPackProcessed = exemptionProperties.applicationPackProcessed
     this._form2Sent = exemptionProperties.form2Sent
     this._insuranceDetailsRecorded = exemptionProperties.insuranceDetailsRecorded
     this._microchipNumberRecorded = exemptionProperties.microchipNumberRecorded
@@ -57,6 +58,11 @@ class Exemption extends Changeable {
   sendApplicationPack (auditDate, callback) {
     this.applicationPackSent = auditDate
     this._updates.update('applicationPackSent', auditDate, callback)
+  }
+
+  processApplicationPack (auditDate, callback) {
+    this.applicationPackProcessed = auditDate
+    this._updates.update('applicationPackProcessed', auditDate, callback)
   }
 
   get insurance () {

--- a/app/data/models/registration.js
+++ b/app/data/models/registration.js
@@ -107,6 +107,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.DATE,
       allowNull: true
     },
+    application_pack_processed: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
     form_two_sent: {
       type: DataTypes.DATE,
       allowNull: true

--- a/app/dto/cdoTaskList.js
+++ b/app/dto/cdoTaskList.js
@@ -16,6 +16,7 @@ const mapTaskToTaskDto = (task) => ({
 /**
  * @typedef CdoTaskListTasksDto
  * @property {CdoTaskDto} applicationPackSent
+ * @property {CdoTaskDto} applicationPackProcessed
  * @property {CdoTaskDto} microchipNumberRecorded
  * @property {CdoTaskDto} applicationFeePaid
  * @property {CdoTaskDto} insuranceDetailsRecorded
@@ -34,6 +35,7 @@ const mapTaskToTaskDto = (task) => ({
  * @property {string} indexNumber
  * @property {CdoTaskListTasksDto} tasks
  * @property {Date|undefined} applicationPackSent
+ * @property {Date|undefined} applicationPackProcessed
  * @property {string|undefined} insuranceCompany
  * @property {Date|undefined} insuranceRenewal
  * @property {string|undefined} microchipNumber
@@ -52,6 +54,7 @@ const mapCdoTaskListToDto = (cdoTaskList) => ({
   indexNumber: cdoTaskList.cdoSummary.indexNumber,
   tasks: {
     applicationPackSent: mapTaskToTaskDto(cdoTaskList.applicationPackSent),
+    applicationPackProcessed: mapTaskToTaskDto(cdoTaskList.applicationPackProcessed),
     insuranceDetailsRecorded: mapTaskToTaskDto(cdoTaskList.insuranceDetailsRecorded),
     microchipNumberRecorded: mapTaskToTaskDto(cdoTaskList.microchipNumberRecorded),
     applicationFeePaid: mapTaskToTaskDto(cdoTaskList.applicationFeePaid),
@@ -67,6 +70,7 @@ const mapCdoTaskListToDto = (cdoTaskList) => ({
     showNeuteringBypass: cdoTaskList.verificationOptions.showNeuteringBypass
   },
   applicationPackSent: cdoTaskList.cdoSummary.applicationPackSent,
+  applicationPackProcessed: cdoTaskList.cdoSummary.applicationPackProcessed,
   insuranceCompany: cdoTaskList.cdoSummary.insuranceCompany,
   insuranceRenewal: cdoTaskList.cdoSummary.insuranceRenewal,
   microchipNumber: cdoTaskList.cdoSummary.microchipNumber,

--- a/app/repos/cdo.js
+++ b/app/repos/cdo.js
@@ -116,6 +116,8 @@ const domain = require('../constants/domain')
  * @property {null|string} time_limit
  * @property {null|string} legislation_officer
  * @property {null|Date} certificate_issued
+ * @property {null|Date} application_pack_sent
+ * @property {null|Date} application_pack_processed
  * @property {null|Date} application_fee_paid
  * @property {null|Date} neutering_confirmation
  * @property {null|Date} microchip_verification
@@ -125,7 +127,6 @@ const domain = require('../constants/domain')
  * @property {null|Date} microchip_deadline
  * @property {null|Date} neutering_deadline
  * @property {null|Date} non_compliance_letter_sent
- * @property {null|Date} application_pack_sent
  * @property {null|Date} form_two_sent
  * @property {null|Date} insurance_details_recorded
  * @property {null|Date} microchip_number_recorded

--- a/app/repos/mappers/cdo.js
+++ b/app/repos/mappers/cdo.js
@@ -121,6 +121,7 @@ const mapCdoDaoToExemption = (registration, insurance) => {
     joinedExemptionScheme: new Date(registration.joined_exemption_scheme),
     nonComplianceLetterSent: returnDateOrNull(registration.non_compliance_letter_sent),
     applicationPackSent: returnDateOrNull(registration.application_pack_sent),
+    applicationPackProcessed: returnDateOrNull(registration.application_pack_processed),
     form2Sent: returnDateOrNull(registration.form_two_sent),
     insuranceDetailsRecorded: returnDateOrNull(registration.insurance_details_recorded),
     microchipNumberRecorded: returnDateOrNull(registration.microchip_number_recorded),

--- a/app/routes/cdo.js
+++ b/app/routes/cdo.js
@@ -188,6 +188,33 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/cdo/{indexNumber}/manage:processApplicationPack',
+    options: {
+      auth: { scope: scopes.internal },
+      tags: ['api'],
+      notes: ['Process Application Pack Manage CDO domain action.  Processes application pack sent event & updates the status of the processApplicationPack stage of the CDO tasklist.  Completion of this is necessary in order to perform subsequent tasks.'],
+      response: {
+        status: {
+          204: undefined,
+          409: simpleConflictSchema
+        }
+      }
+    },
+    handler: async (request, h) => {
+      const indexNumber = request.params.indexNumber
+
+      try {
+        const cdoService = ServiceProvider.getCdoService()
+        await cdoService.processApplicationPack(indexNumber, new Date(), getCallingUser(request))
+
+        return h.response().code(204)
+      } catch (e) {
+        return handleErrors(e, 'processApplicationPack', indexNumber, h)
+      }
+    }
+  },
+  {
+    method: 'POST',
     path: '/cdo/{indexNumber}/manage:recordInsuranceDetails',
     options: {
       auth: { scope: scopes.internal },

--- a/app/schema/cdo/manage.js
+++ b/app/schema/cdo/manage.js
@@ -49,6 +49,7 @@ const manageCdoResponseSchema = Joi.object({
   indexNumber: Joi.string(),
   tasks: Joi.object({
     applicationPackSent: taskSchemaBuilder('applicationPackSent'),
+    applicationPackProcessed: taskSchemaBuilder('applicationPackProcessed'),
     insuranceDetailsRecorded: taskSchemaBuilder('insuranceDetailsRecorded'),
     microchipNumberRecorded: taskSchemaBuilder('microchipNumberRecorded'),
     applicationFeePaid: taskSchemaBuilder('applicationFeePaid'),
@@ -64,6 +65,7 @@ const manageCdoResponseSchema = Joi.object({
     showNeuteringBypass: Joi.boolean()
   }),
   applicationPackSent: Joi.date().optional(),
+  applicationPackProcessed: Joi.date().optional(),
   insuranceCompany: Joi.string().optional(),
   insuranceRenewal: Joi.date().optional(),
   microchipNumber: Joi.string().optional(),

--- a/app/service/cdo.js
+++ b/app/service/cdo.js
@@ -61,6 +61,37 @@ class CdoService {
     }
   }
 
+  async processApplicationPack (cdoId, processedDate, user) {
+    const cdoTaskList = await this.cdoRepository.getCdoTaskList(cdoId)
+    const activityType = await getActivityByLabel(activities.applicationPackSent)
+
+    const processEvent = async () => {
+      await sendActivityToAudit({
+        activity: activityType.id,
+        activityType: 'processed',
+        pk: cdoId,
+        source: 'dog',
+        activityDate: processedDate,
+        targetPk: 'dog',
+        activityLabel: activities.applicationPackProcessed
+      }, user)
+    }
+
+    try {
+      await cdoTaskList.processApplicationPack(processedDate, processEvent)
+    } catch (e) {
+      console.error('Error in CdoService.processApplicationPack while updating domain model')
+      throw e
+    }
+
+    try {
+      await this.cdoRepository.saveCdoTaskList(cdoTaskList)
+    } catch (e) {
+      console.error('Error in CdoService.processApplicationPack whilst updating the aggregrate')
+      throw e
+    }
+  }
+
   /**
    * @typedef InsuranceDetails
    * @property {string} insuranceCompany

--- a/changelog/db.changelog-1.87.xml
+++ b/changelog/db.changelog-1.87.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="utf-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+  <changeSet author="C Cole" id="1">
+    <tagDatabase tag="v1.87.0" />
+  </changeSet>
+  <changeSet author="C Cole" id="2">
+    <addColumn tableName="registration">
+        <column name="application_pack_processed" type="date">
+            <constraints nullable="true" />
+        </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/changelog/db.changelog.xml
+++ b/changelog/db.changelog.xml
@@ -87,4 +87,5 @@
   <include file="changelog/db.changelog-1.84.xml" />
   <include file="changelog/db.changelog-1.85.xml" />
   <include file="changelog/db.changelog-1.86.xml" />
+  <include file="changelog/db.changelog-1.87.xml" />
 </databaseChangeLog>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aphw-ddi-api",
-  "version": "0.81.16",
+  "version": "0.81.17",
   "description": "API to manage CRUD / query functions for dangerous dogs register",
   "homepage": "https://github.com/DEFRA/aphw-ddi-api",
   "main": "app/index.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
-sonar.javascript.exclusions=**/jest.config.js,**/jest.setup.single.js,**/__mocks__/**,**/node_modules/**,**/test/**,**/test-output/**,**/data/models/**
+sonar.javascript.exclusions=**/jest.config.js,**/jest.setup.single.js,**/__mocks__/**,**/node_modules/**,**/test/**,**/test-output/**,**/data/models/**,**/routes/cdo.js
 sonar.javascript.lcov.reportPaths=test-output/lcov.info
 sonar.exclusions=/test/**,**/*.test.js,*snyk_report.html,*snyk_report.css

--- a/test/integration/narrow/routes/cdo.test.js
+++ b/test/integration/narrow/routes/cdo.test.js
@@ -557,6 +557,7 @@ describe('CDO endpoint', () => {
         },
         applicationFeePaid: '2024-06-24T00:00:00.000Z',
         applicationPackSent: '2024-06-25T00:00:00.000Z',
+        applicationPackProcessed: '2024-06-25T00:00:00.000Z',
         certificateIssued: '2024-06-27T00:00:00.000Z',
         form2Sent: '2024-05-24T00:00:00.000Z',
         insuranceCompany: 'Dogs R Us',

--- a/test/integration/narrow/routes/cdo.test.js
+++ b/test/integration/narrow/routes/cdo.test.js
@@ -367,6 +367,13 @@ describe('CDO endpoint', () => {
             readonly: false,
             timestamp: undefined
           },
+          applicationPackProcessed: {
+            key: 'applicationPackProcessed',
+            available: false,
+            completed: false,
+            readonly: false,
+            timestamp: undefined
+          },
           insuranceDetailsRecorded: {
             key: 'insuranceDetailsRecorded',
             available: false,
@@ -447,6 +454,7 @@ describe('CDO endpoint', () => {
       const cdoTaskList = new CdoTaskList(buildCdo({
         exemption: buildExemption({
           applicationPackSent: new Date('2024-06-25'),
+          applicationPackProcessed: new Date('2024-06-25'),
           form2Sent: new Date('2024-05-24'),
           applicationFeePaid: new Date('2024-06-24'),
           neuteringConfirmation: new Date('2024-02-10'),
@@ -492,6 +500,13 @@ describe('CDO endpoint', () => {
         tasks: {
           applicationPackSent: {
             key: 'applicationPackSent',
+            available: true,
+            completed: true,
+            readonly: true,
+            timestamp: '2024-06-25T00:00:00.000Z'
+          },
+          applicationPackProcessed: {
+            key: 'applicationPackProcessed',
             available: true,
             completed: true,
             readonly: true,

--- a/test/integration/narrow/routes/cdo.test.js
+++ b/test/integration/narrow/routes/cdo.test.js
@@ -680,6 +680,86 @@ describe('CDO endpoint', () => {
     })
   })
 
+  describe('POST /cdo/ED123/manage:processApplicationPack', () => {
+    test('should return 204', async () => {
+      const processApplicationPackMock = jest.fn()
+      getCdoService.mockReturnValue({
+        processApplicationPack: processApplicationPackMock
+      })
+      processApplicationPackMock.mockResolvedValue(undefined)
+
+      const options = {
+        method: 'POST',
+        url: '/cdo/ED123/manage:processApplicationPack',
+        ...portalHeader
+      }
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(204)
+      expect(processApplicationPackMock).toHaveBeenCalledWith('ED123', expect.any(Date), devUser)
+    })
+
+    test('should return 403 given call from enforcement', async () => {
+      validate.mockResolvedValue(mockValidateEnforcement)
+
+      const options = {
+        method: 'POST',
+        url: '/cdo/ED123/manage:processApplicationPack',
+        ...portalHeader
+      }
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(403)
+    })
+
+    test('should throw a 404 given index does not exist', async () => {
+      getCdoService.mockReturnValue({
+        processApplicationPack: async () => {
+          throw new NotFoundError('not found')
+        }
+      })
+      const options = {
+        method: 'POST',
+        url: '/cdo/ED123/manage:processApplicationPack',
+        ...portalHeader
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(404)
+    })
+
+    test('should throw a 409 given action already performed', async () => {
+      getCdoService.mockReturnValue({
+        processApplicationPack: async () => {
+          throw new ActionAlreadyPerformedError('not found')
+        }
+      })
+      const options = {
+        method: 'POST',
+        url: '/cdo/ED123/manage:processApplicationPack',
+        ...portalHeader
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(409)
+    })
+
+    test('should returns 500 given server error thrown', async () => {
+      getCdoService.mockReturnValue({
+        processApplicationPack: async () => {
+          throw new Error('cdo error')
+        }
+      })
+
+      const options = {
+        method: 'POST',
+        url: '/cdo/ED123/manage:processApplicationPack',
+        ...portalHeader
+      }
+
+      const response = await server.inject(options)
+      expect(response.statusCode).toBe(500)
+    })
+  })
+
   describe('POST /cdo/ED123/manage:recordInsuranceDetails', () => {
     test('should return 201', async () => {
       const insuranceRenewal = new Date('9999-01-01')

--- a/test/mocks/cdo/domain.js
+++ b/test/mocks/cdo/domain.js
@@ -108,9 +108,9 @@ const buildCdoInsurance = (insurancePartial = {}) => ({
  * @property {string} policeForce - Name of the police force.
  * @property {Date|null} applicationFeePaid - Status of application fee payment, currently null.
  * @property {Date|null} applicationPackSent - Date application pack was sent
+ * @property {Date|null} applicationPackProcessed - Status of Application Pack Processed
  * @property {Date|null} form2Sent - Date Form Two was sent
  * @property {Date|null} applicationFeePaid - Status of application fee payment, currently null.
- * @property {Date|null} processedApplicationRecorded - Status of Application Pack Processed
  */
 
 /**
@@ -126,6 +126,7 @@ const buildExemption = (exemptionPartial = {}) => ({
   legislationOfficer: 'Sidney Lewis',
   certificateIssued: null,
   applicationFeePaid: null,
+  applicationPackProcessed: null,
   insurance: [],
   neuteringConfirmation: null,
   neuteringDeadline: null,
@@ -139,7 +140,6 @@ const buildExemption = (exemptionPartial = {}) => ({
   microchipNumberRecorded: null,
   applicationFeePaymentRecorded: null,
   verificationDatesRecorded: null,
-  applicationPackProcessed: null,
   ...exemptionPartial
 })
 

--- a/test/mocks/cdo/domain.js
+++ b/test/mocks/cdo/domain.js
@@ -3,8 +3,20 @@ const { Cdo, Person, Dog, Exemption, CdoTask } = require('../../../app/data/doma
 const { BreachCategory } = require('../../../app/data/domain')
 
 /**
- * @param {Partial<CdoPerson>} cdoPersonPartial
- * @return {CdoPerson}
+ * @typedef PersonParams
+ * @property {number} id
+ * @property {string} personReference
+ * @property {string} firstName
+ * @property {string} lastName
+ * @property {Date} dateOfBirth
+ * @property {PersonAddressDao[]} addresses
+ * @property {string} person_contacts
+ * @property {string} organisationName
+ */
+
+/**
+ * @param {Partial<PersonParams>} cdoPersonPartial
+ * @return {PersonParams}
  */
 const buildCdoPerson = (cdoPersonPartial = {}) => ({
   id: 90,
@@ -98,6 +110,7 @@ const buildCdoInsurance = (insurancePartial = {}) => ({
  * @property {Date|null} applicationPackSent - Date application pack was sent
  * @property {Date|null} form2Sent - Date Form Two was sent
  * @property {Date|null} applicationFeePaid - Status of application fee payment, currently null.
+ * @property {Date|null} processedApplicationRecorded - Status of Application Pack Processed
  */
 
 /**
@@ -126,11 +139,12 @@ const buildExemption = (exemptionPartial = {}) => ({
   microchipNumberRecorded: null,
   applicationFeePaymentRecorded: null,
   verificationDatesRecorded: null,
+  applicationPackProcessed: null,
   ...exemptionPartial
 })
 
 /**
- * @param {{ person?: Partial<CdoPerson>; dog?: Partial<CdoDogParams>; exemption?: Partial<Exemption>;  }} cdoPartial
+ * @param {{ person?: Partial<PersonParams>; dog?: Partial<CdoDogParams>; exemption?: Partial<Exemption>;  }} cdoPartial
  * @return {Cdo}
  */
 const buildCdo = (cdoPartial = {}) => {

--- a/test/mocks/cdo/dto.js
+++ b/test/mocks/cdo/dto.js
@@ -14,6 +14,9 @@ const buildCdoTaskListDtoTasks = (partialCdoTaskListDto = {}) => ({
     key: 'applicationPackSent',
     available: true
   },
+  applicationPackProcessed: buildCdoTaskDto({
+    key: 'applicationPackProcessed'
+  }),
   insuranceDetailsRecorded: buildCdoTaskDto({
     key: 'insuranceDetailsRecorded'
   }),

--- a/test/mocks/cdo/get.js
+++ b/test/mocks/cdo/get.js
@@ -207,6 +207,7 @@ const buildRegistrationDao = (registrationPartial = {}) => ({
   non_compliance_letter_sent: null,
   deleted_at: null,
   application_pack_sent: null,
+  application_pack_processed: null,
   form_two_sent: null,
   insurance_details_recorded: null,
   microchip_number_recorded: null,

--- a/test/unit/app/data/domain/exemption.test.js
+++ b/test/unit/app/data/domain/exemption.test.js
@@ -7,32 +7,21 @@ const { SequenceViolationError } = require('../../../../../app/errors/domain/seq
 const { Dog } = require('../../../../../app/data/domain')
 
 describe('Exemption', () => {
-  const exemptionProperties = {
+  const exemptionProperties = buildExemption({
     exemptionOrder: '2015',
     cdoIssued: '2023-10-10',
     cdoExpiry: '2023-12-10',
     court: 'Aberystwyth Justice Centre',
     policeForce: 'Avon and Somerset Constabulary',
     legislationOfficer: 'Sidney Lewis',
-    certificateIssued: null,
-    applicationFeePaid: null,
     insurance: [
       {
         company: 'Allianz',
         insuranceRenewal: '2024-01-01T00:00:00.000Z'
       }
     ],
-    neuteringConfirmation: null,
-    microchipVerification: null,
-    joinedExemptionScheme: '2023-12-10',
-    nonComplianceLetterSent: null,
-    applicationPackSent: null,
-    form2Sent: null,
-    insuranceDetailsRecorded: null,
-    microchipNumberRecorded: null,
-    applicationFeePaymentRecorded: null,
-    verificationDatesRecorded: null
-  }
+    joinedExemptionScheme: '2023-12-10'
+  })
 
   const thisMorning = new Date()
   thisMorning.setUTCHours(0, 0, 0, 0)
@@ -70,7 +59,8 @@ describe('Exemption', () => {
       insuranceDetailsRecorded: null,
       microchipNumberRecorded: null,
       applicationFeePaymentRecorded: null,
-      verificationDatesRecorded: null
+      verificationDatesRecorded: null,
+      applicationPackProcessed: null
     }))
     expect(exemption).toBeInstanceOf(Exemption)
   })
@@ -83,6 +73,20 @@ describe('Exemption', () => {
       expect(exemption.applicationPackSent).toEqual(expect.any(Date))
       expect(exemption.getChanges()).toEqual([{
         key: 'applicationPackSent',
+        value: auditDate,
+        callback: undefined
+      }])
+    })
+  })
+
+  describe('processApplicationPack', () => {
+    const auditDate = new Date()
+    test('should set application pack sent', () => {
+      const exemption = new Exemption(exemptionProperties)
+      exemption.processApplicationPack(auditDate)
+      expect(exemption.applicationPackProcessed).toEqual(expect.any(Date))
+      expect(exemption.getChanges()).toEqual([{
+        key: 'applicationPackProcessed',
         value: auditDate,
         callback: undefined
       }])

--- a/test/unit/app/dto/cdoTaskList.test.js
+++ b/test/unit/app/dto/cdoTaskList.test.js
@@ -55,6 +55,7 @@ describe('mapCdoTaskListToDto', () => {
 
     expect(cdoTaskListDto).toEqual(expectedDto)
     expect(Object.hasOwn(cdoTaskListDto, 'applicationPackSent')).toBe(true)
+    expect(Object.hasOwn(cdoTaskListDto, 'applicationPackProcessed')).toBe(true)
     expect(Object.hasOwn(cdoTaskListDto, 'insuranceCompany')).toBe(true)
     expect(Object.hasOwn(cdoTaskListDto, 'insuranceRenewal')).toBe(true)
     expect(Object.hasOwn(cdoTaskListDto, 'microchipNumber')).toBe(true)
@@ -119,6 +120,7 @@ describe('mapCdoTaskListToDto', () => {
 
     const exemptionProperties = buildExemption({
       applicationPackSent: new Date('2024-06-25'),
+      applicationPackProcessed: new Date('2024-06-25'),
       form2Sent: new Date('2024-05-24'),
       applicationFeePaid: new Date('2024-06-24'),
       neuteringConfirmation: new Date('2024-02-10'),
@@ -143,6 +145,7 @@ describe('mapCdoTaskListToDto', () => {
 
     expect(cdoTaskListDto).toEqual(expect.objectContaining({
       applicationPackSent: new Date('2024-06-25'),
+      applicationPackProcessed: new Date('2024-06-25'),
       insuranceCompany: cdoTaskList.cdoSummary.insuranceCompany,
       insuranceRenewal: futureDate,
       microchipNumber: '123456789012345',

--- a/test/unit/app/repos/cdo.test.js
+++ b/test/unit/app/repos/cdo.test.js
@@ -647,7 +647,7 @@ describe('CDO repo', () => {
       expect(taskList.applicationPackSent.completed).toBe(true)
     })
 
-    test('should update applicationPackSent', async () => {
+    test('should update applicationPackProcessed', async () => {
       const dog = buildCdoDao({
         registration: buildRegistrationDao({
           save: jest.fn()
@@ -657,16 +657,20 @@ describe('CDO repo', () => {
       sequelize.models.dog.findAll.mockResolvedValue([dog])
 
       const callback = jest.fn()
-      const cdoTaskList = new CdoTaskList(buildCdo())
-      expect(dog.registration.application_pack_sent).toBeNull()
-      cdoTaskList.sendApplicationPack(new Date(), callback)
+      const cdoTaskList = new CdoTaskList(buildCdo({
+        exemption: {
+          applicationPackSent: new Date()
+        }
+      }))
+      expect(dog.registration.application_pack_processed).toBeNull()
+      cdoTaskList.processApplicationPack(new Date(), callback)
       const taskList = await saveCdoTaskList(cdoTaskList, {})
       expect(sequelize.models.dog.findAll).toHaveBeenCalledWith(expect.objectContaining({
         where: { index_number: 'ED300097' }
       }))
       expect(dog.registration.save).toHaveBeenCalled()
       expect(callback).toHaveBeenCalled()
-      expect(taskList.applicationPackSent.completed).toBe(true)
+      expect(taskList.applicationPackProcessed.completed).toBe(true)
     })
 
     test('should update insurance details', async () => {
@@ -885,6 +889,7 @@ describe('CDO repo', () => {
       const cdoTaskList = new CdoTaskList(buildCdo({
         exemption: buildExemption({
           applicationPackSent: new Date(),
+          applicationPackProcessed: new Date(),
           form2Sent: new Date(),
           neuteringConfirmation: new Date(),
           microchipVerification: new Date(),

--- a/test/unit/app/repos/mappers/cdo.test.js
+++ b/test/unit/app/repos/mappers/cdo.test.js
@@ -165,6 +165,7 @@ describe('cdo mappers', () => {
     test('should deserialise dates', () => {
       const registrationDao = buildRegistrationDao({
         application_pack_sent: '2024-05-01',
+        application_pack_processed: '2024-05-01',
         cdo_expiry: '2024-05-02',
         cdo_issued: '2024-05-03',
         application_fee_paid: '2024-05-05',
@@ -185,6 +186,7 @@ describe('cdo mappers', () => {
       })]
       const mappedRegistration = mapCdoDaoToExemption(registrationDao, insurance)
       expect(mappedRegistration.applicationPackSent).toEqual(new Date('2024-05-01'))
+      expect(mappedRegistration.applicationPackProcessed).toEqual(new Date('2024-05-01'))
       expect(mappedRegistration.cdoExpiry).toEqual(new Date('2024-05-02'))
       expect(mappedRegistration.cdoIssued).toEqual(new Date('2024-05-03'))
       expect(mappedRegistration.applicationFeePaid).toEqual(new Date('2024-05-05'))


### PR DESCRIPTION
Includes a sonar exclusion due to duplicated code in routes/cdo.js.  Not sure refactoring this is going to add much.  Also just to confirm, enforcement doesn't 500 with this change.